### PR TITLE
Fix an issue where offset would stick even when collection changes

### DIFF
--- a/src/si-table/directives/tr.js
+++ b/src/si-table/directives/tr.js
@@ -30,6 +30,14 @@ angular.module('siTable.directives').directive('tr', function() {
 
           scope.paginationParams = controller.paginationParams;
 
+          if (attrs.ngRepeat) {
+            var matches = attrs.ngRepeat.match(/^\s*([\s\S]+?)\s+in\s+([\s\S]+?)(?:\s+track\s+by\s+([\s\S]+?))?\s*$/),
+              collection = matches[2].split('|')[0].trim();
+            scope.$watchCollection(collection, function() {
+              scope.paginationParams.offset = 0;
+            });
+          }
+
           scope.$watch('paginationParams.remote', function(remote) {
             if (remote) {
               scope.sortingParams = {};


### PR DESCRIPTION
Steps to reproduce:
1. Change to a page other than 1
2. Remove everything in the collection except for 1 item

Issue: Offset doesn't change, so you end up with an empty table.
